### PR TITLE
add hack to delay retries for machines that errored with "No valid host was found"

### DIFF
--- a/pkg/driver/executor/errors.go
+++ b/pkg/driver/executor/errors.go
@@ -9,7 +9,11 @@ import (
 )
 
 // NoValidHost is a part of the error message returned when there is no valid host in the zone to deploy a VM.
-const NoValidHost = "not enough hosts available"
+// Matches:
+//
+//	"No valid host was found."
+//	"No valid host was found. There are not enough hosts available."
+const NoValidHost = "No valid host was found"
 
 var (
 	// ErrNotFound is returned when the requested resource could not be found.

--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
@@ -177,19 +176,12 @@ func (ex *Executor) waitForServerStatus(ctx context.Context, serverID string, pe
 			}
 
 			klog.V(5).Infof("waiting for server [ID=%q] and current status %v, to reach status %v.", serverID, current.Status, target)
-			// NOTE: for the createMachine call this is client.ServerStatusActive
 			if strSliceContains(target, current.Status) {
 				return true, nil
 			}
 
 			// if there is no pending statuses defined or current status is in the pending list, then continue polling
 			if len(pending) == 0 || strSliceContains(pending, current.Status) {
-				return false, nil
-			}
-
-			// HACK: machines that are in error because of "No valid host was found" error are considered as pending
-			if current.Status == client.ServerStatusError && current.Fault.Code == 500 && strings.Contains(current.Fault.Message, "No valid host was found.") {
-				klog.V(1).Infof("server [ID=%q] has status 500 with a %q error, continue to poll to reduce amount of recreates", serverID, "No valid host was found.")
 				return false, nil
 			}
 


### PR DESCRIPTION
Without this, we would recreate machine **and** volume roughly every 3min. Which is currently too often for us.